### PR TITLE
Added Souvenir support for Bob Barks

### DIFF
--- a/Assets/Question.cs
+++ b/Assets/Question.cs
@@ -61,6 +61,13 @@ namespace Souvenir
         [SouvenirQuestion("What was the last letter pressed on {0}?", "Blockbusters", 6, "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z")]
         BlockbustersLastLetter,
 
+        [SouvenirQuestion("What was the {1} indicator label in {0}?", "Bob Barks", 6, "BOB", "CAR", "CLR", "IND", "FRK", "FRQ", "MSA", "NSA", "SIG", "SND", "TRN", "BUB", "DOG", "ETC", "KEY",
+            ExampleExtraFormatArguments = new[] { "top left", "top right", "bottom left", "bottom right" }, ExampleExtraFormatArgumentGroupSize = 1)]
+        BobBarksIndicators,
+        [SouvenirQuestion("Which button flashed {1} in sequence in {0}?", "Bob Barks", 4, "top left", "top right", "bottom left", "bottom right",
+            ExampleExtraFormatArguments = new[] { "first", "second", "third", "4th", "5th" }, ExampleExtraFormatArgumentGroupSize = 1)]
+        BobBarksPositions,
+
         [SouvenirQuestion("What letter was initially visible on {0}?", "Boggle", 6, null, ExampleAnswers = new[] { "A", "E", "G", "M", "T", "W" })]
         BoggleLetters,
 

--- a/Assets/SouvenirModule.cs
+++ b/Assets/SouvenirModule.cs
@@ -1700,26 +1700,20 @@ public class SouvenirModule : MonoBehaviour
         string[] validLabels = { "BOB", "CAR", "CLR", "IND", "FRK", "FRQ", "MSA", "NSA", "SIG", "SND", "TRN", "BUB", "DOG", "ETC", "KEY" };
 
         int[] indicators = fldIndicators.Get();
-        if (indicators.Length != 4)
-        {
-            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘assigned’ has unexpected length ({1}).", _moduleId, indicators.Length);
+        if (indicators == null)
             yield break;
-        }
-        if (indicators.Any(idn => idn < 0 || idn > validLabels.Length))
+        if (indicators.Length != 4 || indicators.Any(idn => idn < 0 || idn >= validLabels.Length))
         {
-            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘assigned’ has an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘assigned’ has unexpected length or an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
             yield break;
         }
 
         int[] flashes = fldFlashes.Get();
-        if (flashes.Length != 5)
-        {
-            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘stages’ has unexpected length ({1}).", _moduleId, flashes.Length);
+        if (flashes == null)
             yield break;
-        }
-        if (flashes.Any(fn => fn < 0 || fn > validDirections.Length))
+        if (flashes.Length != 5 || flashes.Any(fn => fn < 0 || fn >= validDirections.Length))
         {
-            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘stages’ has an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘stages’ has unexpected length or an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
             yield break;
         }
 
@@ -1727,14 +1721,14 @@ public class SouvenirModule : MonoBehaviour
         string[] labelsOnModule = { validLabels[indicators[0]], validLabels[indicators[1]], validLabels[indicators[2]], validLabels[indicators[3]] };
 
         addQuestions(module,
-            Enumerable.Range(0, 4).Select(ix => makeQuestion(Question.BobBarksIndicators, _BobBarks, 
-                correctAnswers: new[] { labelsOnModule[ix] }, 
+            Enumerable.Range(0, 4).Select(ix => makeQuestion(Question.BobBarksIndicators, _BobBarks,
+                correctAnswers: new[] { labelsOnModule[ix] },
                 formatArgs: new[] { validDirections[ix] },
                 preferredWrongAnswers: labelsOnModule.Except(new[] { labelsOnModule[ix] }).ToArray()
             )).Concat(
-            Enumerable.Range(0, 5).Select(ix => makeQuestion(Question.BobBarksPositions, _BobBarks, 
-                correctAnswers: new[] { validDirections[flashes[ix]] }, 
-                formatArgs: new[] { ordinal(ix + 1) } ))
+            Enumerable.Range(0, 5).Select(ix => makeQuestion(Question.BobBarksPositions, _BobBarks,
+                correctAnswers: new[] { validDirections[flashes[ix]] },
+                formatArgs: new[] { ordinal(ix + 1) }))
             ));
     }
 

--- a/Assets/SouvenirModule.cs
+++ b/Assets/SouvenirModule.cs
@@ -88,6 +88,7 @@ public class SouvenirModule : MonoBehaviour
     const string _Bitmaps = "BitmapsModule";
     const string _BlindMaze = "BlindMaze";
     const string _Blockbusters = "blockbusters";
+    const string _BobBarks = "ksmBobBarks";
     const string _Boggle = "boggle";
     const string _Braille = "BrailleModule";
     const string _BrokenButtons = "BrokenButtonsModule";
@@ -255,6 +256,7 @@ public class SouvenirModule : MonoBehaviour
             { _Bitmaps, ProcessBitmaps },
             { _BlindMaze, ProcessBlindMaze },
             { _Blockbusters, ProcessBlockbusters },
+            { _BobBarks, ProcessBobBarks },
             { _Boggle, ProcessBoggle },
             { _Braille, ProcessBraille },
             { _BrokenButtons, ProcessBrokenButtons },
@@ -1677,6 +1679,63 @@ public class SouvenirModule : MonoBehaviour
         }
 
         addQuestion(module, Question.BlockbustersLastLetter, correctAnswers: new[] { lastPress }, preferredWrongAnswers: legalLetters.ToArray());
+    }
+
+    private IEnumerable<object> ProcessBobBarks(KMBombModule module)
+    {
+        var comp = GetComponent(module, "BobBarks");
+        var fldSolved = GetField<bool>(comp, "moduleSolved");
+        var fldIndicators = GetField<int[]>(comp, "assigned");
+        var fldFlashes = GetField<int[]>(comp, "stages");
+
+        if (comp == null || fldSolved == null || fldIndicators == null || fldFlashes == null)
+            yield break;
+
+        while (!fldSolved.Get())
+            yield return new WaitForSeconds(.1f);
+
+        _modulesSolved.IncSafe(_BobBarks);
+
+        string[] validDirections = { "top left", "top right", "bottom left", "bottom right" };
+        string[] validLabels = { "BOB", "CAR", "CLR", "IND", "FRK", "FRQ", "MSA", "NSA", "SIG", "SND", "TRN", "BUB", "DOG", "ETC", "KEY" };
+
+        int[] indicators = fldIndicators.Get();
+        if (indicators.Length != 4)
+        {
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘assigned’ has unexpected length ({1}).", _moduleId, indicators.Length);
+            yield break;
+        }
+        if (indicators.Any(idn => idn < 0 || idn > validLabels.Length))
+        {
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘assigned’ has an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
+            yield break;
+        }
+
+        int[] flashes = fldFlashes.Get();
+        if (flashes.Length != 5)
+        {
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘stages’ has unexpected length ({1}).", _moduleId, flashes.Length);
+            yield break;
+        }
+        if (flashes.Any(fn => fn < 0 || fn > validDirections.Length))
+        {
+            Debug.LogFormat("<Souvenir #{0}> Abandoning Bob Barks because ‘stages’ has an unexpected value in it [{1}].", _moduleId, indicators.JoinString(", "));
+            yield break;
+        }
+
+        // To provide preferred wrong answers, mostly.
+        string[] labelsOnModule = { validLabels[indicators[0]], validLabels[indicators[1]], validLabels[indicators[2]], validLabels[indicators[3]] };
+
+        addQuestions(module,
+            Enumerable.Range(0, 4).Select(ix => makeQuestion(Question.BobBarksIndicators, _BobBarks, 
+                correctAnswers: new[] { labelsOnModule[ix] }, 
+                formatArgs: new[] { validDirections[ix] },
+                preferredWrongAnswers: labelsOnModule.Except(new[] { labelsOnModule[ix] }).ToArray()
+            )).Concat(
+            Enumerable.Range(0, 5).Select(ix => makeQuestion(Question.BobBarksPositions, _BobBarks, 
+                correctAnswers: new[] { validDirections[flashes[ix]] }, 
+                formatArgs: new[] { ordinal(ix + 1) } ))
+            ));
     }
 
     private IEnumerable<object> ProcessBoggle(KMBombModule module)

--- a/Manual/Souvenir.html
+++ b/Manual/Souvenir.html
@@ -63,6 +63,7 @@
                     <tr><th class='module'>Bitmaps</th><td><div>How many pixels were black/white in each quadrant?</div></td></tr>
                     <tr><th class='module'>Blind Maze</th><td><div>What colors were the buttons?</div><div>Which maze did you solve the module on?</div></td></tr>
                     <tr><th class='module'>Blockbusters</th><td><div>What was the last letter pressed?</div></td></tr>
+                    <tr><th class='module'>Bob Barks</th><td><div>What were the indicator labels in each position?</div><div>Which buttons flashed in each stage?</div></td></tr>
                     <tr><th class='module'>Boggle</th><td><div>Which letters were initially visible?</div></td></tr>
                     <tr><th class='module'>Braille</th><td><div>What was the final solution word?</div></td></tr>
                     <tr><th class='module'>Broken Buttons</th><td><div>What were the correct buttons you pressed?</div></td></tr>


### PR DESCRIPTION
The following questions are asked:
* What was the [top left] indicator label in [Bob Barks]? (These are hidden already when any correct input is made, so they will always be hidden when it is solved.)
* Which button flashed [first] in sequence in [Bob Barks]? (The flashing sequence stops after solve, as you could probably guess.)

Manual is updated to match, though I can't fix the PDF manual due to Firefox insisting on erasing the SVG and all other images whenever I try to make one. Please let me know if I've forgotten anything other than that, since this is the first module I've handled Souvenir support for. I've tested this locally and everything works perfectly, though, so I'm hoping that isn't the case.