### PR TITLE
Forget Any Color - Allow cylinder duplicates

### DIFF
--- a/Assets/Question.cs
+++ b/Assets/Question.cs
@@ -944,7 +944,7 @@ namespace Souvenir
         [AnswerGenerator.Integers(0, 9)]
         RedArrowsStartNumber,
 
-        [SouvenirQuestion("Which condition was the solving condition in {0}?", "Reformed Role Reversal", AnswerLayout.ThreeColumns6Answers, "first", "second", "third", "4th", "5th", "6th", "7th", "8th")]
+        [SouvenirQuestion("Which condition was the solving condition in {0}?", "Reformed Role Reversal", AnswerLayout.ThreeColumns6Answers, "second", "third", "4th", "5th", "6th", "7th", "8th")]
         ReformedRoleReversalCondition,
         [SouvenirQuestion("What color was the {1} wire in {0}?", "Reformed Role Reversal", AnswerLayout.ThreeColumns6Answers, "Navy", "Lapis", "Blue", "Sky", "Teal", "Plum", "Violet", "Purple", "Magenta", "Lavender",
             ExampleExtraFormatArguments = new[] { "first", "second", "third", "4th", "5th", "6th", "7th", "8th", "9th", "10th" }, ExampleExtraFormatArgumentGroupSize = 1)]

--- a/Assets/SouvenirModule.cs
+++ b/Assets/SouvenirModule.cs
@@ -3634,10 +3634,10 @@ public class SouvenirModule : MonoBehaviour
 
         var colorNames = new[] { "Red", "Orange", "Yellow", "Green", "Cyan", "Blue", "Purple", "White" };
         var figureNames = new[] { "LLLMR", "LMMMR", "LMRRR", "LMMRR", "LLMRR", "LLMMR" };
-        var correctCylinder = Enumerable.Range(0, 2).Select(ix => colorNames[(int) cylinders.GetValue(randomStage, ix)]).JoinString(", ");
+        var correctCylinder = Enumerable.Range(0, 3).Select(ix => colorNames[(int) cylinders.GetValue(randomStage, ix)]).JoinString(", ");
         var preferredCylinders = new HashSet<string> { correctCylinder };
         while (preferredCylinders.Count < 6)
-            preferredCylinders.Add(Enumerable.Range(0, colorNames.Length).ToArray().Shuffle().Select(ix => colorNames[ix]).JoinString(", "));
+            preferredCylinders.Add(Enumerable.Range(0, 3).Select(i => colorNames.PickRandom()).Join(", ") );
 
         addQuestions(module,
             makeQuestion(Question.ForgetAnyColorCylinder, _ForgetAnyColor, new[] { (randomStage + 1).ToString() },


### PR DESCRIPTION
Assets/Question.cs (line 947): Reformed Role Reversal cannot have its answer be the first condition in any circumstance.
Assets/SouvenirModule.cs (line 3637): It grabbed the first 2 colored cylinders instead of all 3 as the answer.
Assets/SouvenirModule.cs (line 3640): Generates answers that don't exclude duplicate cylinders, since it is allowed in the module.