### PR TITLE
Module Maze: remove gSprites array

### DIFF
--- a/Assets/SouvenirModule.cs
+++ b/Assets/SouvenirModule.cs
@@ -5872,7 +5872,7 @@ public class SouvenirModule : MonoBehaviour
     private IEnumerable<object> ProcessModuleMaze(KMBombModule module)
     {
         var comp = GetComponent(module, "ModuleMazeModule");
-        var fldSprites = GetArrayField<Sprite>(comp, "gSprites", true);
+        var fldSprites = GetArrayField<Sprite>(comp, "sprites", true);
         var fldSolved = GetField<bool>(comp, "solved");
 
         while (!fldSolved.Get())


### PR DESCRIPTION
Module Maze - all sprites are now available in the sprites array, and gSprites has been removed. The gSprites (grayscaleSprites) array was created for Souvenir support, back when the icons on the screen were intended to be in grayscale as opposed to in color. This feature was removed soon after its implementation, as such there is no need for two separate sprite arrays.