### PR TITLE
Enable building SouvenirLib through .NET CLI

### DIFF
--- a/Lib/SouvenirLib.csproj
+++ b/Lib/SouvenirLib.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Souvenir</RootNamespace>
     <AssemblyName>SouvenirLib</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <LangVersion>8.0</LangVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
@@ -19,11 +20,17 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <GameFolder Condition="'$(GameFolder)' == ''">C:\Program Files (x86)\Steam\steamapps\common\Keep Talking and Nobody Explodes\</GameFolder>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="ValueTupleBridge" Version="0.1.5" GeneratePathProperty="true" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -95,8 +102,8 @@
       <HintPath>$(GameFolder)ktane_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ValueTupleBridge, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\ValueTupleBridge.0.1.5\lib\net35\ValueTupleBridge.dll</HintPath>
+    <Reference Include="ValueTupleBridge">
+      <HintPath>$(PkgValueTupleBridge)\lib\net35\ValueTupleBridge.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -154,9 +161,6 @@
     <Compile Include="TranslationInfo.cs" />
     <Compile Include="TranslationJA.cs" />
     <Compile Include="Ut.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Lib/packages.config
+++ b/Lib/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="ValueTupleBridge" version="0.1.5" targetFramework="net35" />
-</packages>


### PR DESCRIPTION
With some people migrating to using VS Code as opposed to Visual Studio, I've been looking to make it easier to build projects without requiring Visual Studio.
VS Code itself doesn't come with the ability to build .NET Libraries, so we can use the .NET CLI to build projects in place of VS. So while this PR is for VSCode compatibility, it's actually targeting building with the .NET CLI.
This change should be compatible with Visual Studio.

- To enable Intellisense in VSCode, move LangVersion from release to debug configuration. This doesn't appear to affect VS.

- I had issues getting ValueTupleBridge to be detected properly on dotnet build, so I had to reference the nuget file directly. I think the .NET CLI is supposed to do this by default but it's not working. Fortunately, MSBuild comes with a GeneratePathPropery that allows me to use the NuGet location for the file.

- Add a new reference to Microsoft.NETFramework.ReferenceAssemblies that allows .NET CLI to reference .NET Framework assemblies.